### PR TITLE
Diffuser bug fixes; fix truncation of leading zeros in returned binary secrets.

### DIFF
--- a/Compatibility.txt
+++ b/Compatibility.txt
@@ -158,3 +158,9 @@ then hello.txt.gpg was generated)
 
 You can then use any 2 of the above 3 shares and the generated GPG file in 
 SecretSplitter to decrypt it.
+
+**************************************************************************
+Shares produced by version 0.20 of this program may not function properly
+with earlier versions of this program; shares produced by earlier versions 
+of this program my not function properly with version 0.20 of this program.  
+**************************************************************************

--- a/SecretSplitter/Security/Cryptography/SecretSplitter.cs
+++ b/SecretSplitter/Security/Cryptography/SecretSplitter.cs
@@ -149,7 +149,7 @@ namespace Moserware.Security.Cryptography {
 
 namespace Moserware.Security.Cryptography.Versioning {
     public static class VersionInfo {
-        public const string CurrentVersionString = "0.12";
+        public const string CurrentVersionString = "0.20";
         public static Version CurrentVersion = new Version(CurrentVersionString);
     }
 }


### PR DESCRIPTION
The diffuser was not handling padding in a manner compatible with ssss-split; in some cases shares were produced SecretSplitter that could not be used to recover the secret (about .4% probability).

When binary secrets with leading nulls were recovered, those leading nulls were not present.

These problems are fixed in this commit, but some older shares, when used with this version, might not recover the correct secret.  I've made some comments about this in the compatibility.txt file.  But in truth I believe the newer program will successfully handle more shares correctly than the old program.